### PR TITLE
test terraform integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,4 @@ cython_debug/
 #.idea/
 .DS_Store
 .python-version
+terraform/*.json

--- a/README.md
+++ b/README.md
@@ -2,3 +2,4 @@
 ```bash
 docker run -p 3000:3000 -e BENTO_SERVICE_NAME=class_svc bento-ml
 ```
+Allow Vertex API

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,7 @@
+provider "google" {
+  region      = "us-central1"
+}
+
+resource "google_project_service" "vertex_ai" {
+  service = "aiplatform.googleapis.com"
+}


### PR DESCRIPTION
This PR adds a terraform module that enables the Vertex AI on the GCP project, having previously set up a Terraform Cloud project that connects to the repo.