### PR TITLE
fix dockerfile command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ WORKDIR /app
 
 COPY src/__init__.py /app/src/__init__.py
 COPY src/runners.py /app/src/runners.py
+COPY src/services.py /app/src/services.py
 COPY requirements.txt /app/requirements.txt
 
 RUN pip install -r requirements.txt
@@ -11,4 +12,4 @@ RUN pip install -r requirements.txt
 ARG BENTO_SERVICE_NAME
 ENV BENTO_SERVICE_NAME=$BENTO_SERVICE_NAME
 
-CMD bentoml serve src/runners.py:${BENTO_SERVICE_NAME}
+CMD bentoml serve src/services.py:${BENTO_SERVICE_NAME}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Model Deployment
 ```bash
-docker run -p 3000:3000 -e BENTO_SERVICE_NAME=class_svc bento-ml
+docker run -p 3000:3000 -e BENTO_SERVICE_NAME=bert_svc bento-ml
 ```
 Allow Vertex API


### PR DESCRIPTION
This PR fixes the `CMD` at the `Dockerfile`, which was incorrectly pointing at the `runners.py` file instead of `services.py`.